### PR TITLE
Fix boto3.client() error #20210610

### DIFF
--- a/trigger_textFileDownloadFunction_script.py
+++ b/trigger_textFileDownloadFunction_script.py
@@ -4,11 +4,13 @@ import time
 
 aws_access_key_id = input("Enter the AWS access key ID for your sandbox: ")
 aws_secret_access_key = input("Enter the AWS secret access key for your sandbox: ")
+region_name = input("Enter the AWS Region for your sandbox: ")
 
 client = boto3.client(
     'lambda',
     aws_access_key_id=aws_access_key_id,
-    aws_secret_access_key=aws_secret_access_key
+    aws_secret_access_key=aws_secret_access_key,
+    region_name=region_name
 )
 
 i = 1


### PR DESCRIPTION
It was missing the variable "region_name" used by boto3.client().